### PR TITLE
Fix pyproject.toml and README and updated preprocessing of packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@
 fip -h
 
 # Convert PCAP to image
-fip -r /PATH/PCAPs -w /PATH/IMAGES
+fip extract -r /PATH/PCAPs -w /PATH/IMAGES
 ```

--- a/fip/packets.py
+++ b/fip/packets.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from scapy.all import IP, Ether, Packet, wrpcap, rdpcap, RandIP, RandMAC
+from scapy.all import IP, IPv6, Ether, Packet, wrpcap, rdpcap, RandIP, RandMAC
 
 import os
 
@@ -70,6 +70,9 @@ class PacketProcessor(ABC):
         if processed_packet.haslayer(IP):
             processed_packet[IP].src = RandIP()._fix()
             processed_packet[IP].dst =RandIP()._fix()
+        elif processed_packet.haslayer(IPv6):
+            processed_packet[IPv6].src = RandIP()._fix()
+            processed_packet[IPv6].dst = RandIP()._fix()
         return processed_packet
 
     def __exit__(self, exc_type, exc_value, tracback) -> None:
@@ -89,6 +92,10 @@ class HTTPPacketProcessor(PacketProcessor):
         if processed_packet.haslayer(IP):
             processed_packet[IP].src = RandIP()._fix()
             processed_packet[IP].dst =RandIP()._fix()
+        elif processed_packet.haslayer(IPv6):
+            processed_packet[IPv6].src = RandIP()._fix()
+            processed_packet[IPv6].dst = RandIP()._fix()
+
 
         return processed_packet
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,12 @@ license = { file="LICENSE" }
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: EUPL",
+    "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
     "Operating System :: OS Independent",
 ]
+
+[project.scripts]
+fip = "cli.FlowImageProcessor:cli"
 
 [project.urls]
 "Homepage" = "https://github.com/stefanDeveloper/flow-image-processor"


### PR DESCRIPTION
- I could only start the image conversion by using "fip extract -r" instead of only "fip -r" so i updated the README
- In the pyproject.toml the license did not work for me so i changed it to the license specified at https://pypi.org/classifiers/
- Also in the pyproject.toml i added a command line entry point 
- I added IPv6 Layer checks to the preprocessing of layers since apparently IP is only for IPv4 Layer